### PR TITLE
chore: Updates to CI workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -182,7 +182,7 @@ jobs:
 
   build-vegafusion-python-osx-64:
     if: inputs.build-all-platforms
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -214,7 +214,7 @@ jobs:
 
   build-vegafusion-python-osx-arm64:
     if: inputs.build-all-platforms
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Check out repository code
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   build-and-test:
@@ -14,3 +15,4 @@ jobs:
       build-all-platforms: false
     permissions:
       contents: read
+      actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,29 @@ jobs:
       contents: read
       actions: write
 
+  attach-wheels-to-release:
+    name: Attach wheels to GitHub Release
+    runs-on: ubuntu-latest
+    needs: [build-and-test]
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Download all wheel artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: python-wheels-*
+          path: wheels/
+          merge-multiple: true
+      - name: List downloaded wheels
+        run: ls -lR wheels/
+      - name: Upload wheels to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          gh release upload ${{ github.ref_name }} wheels/* --clobber
+
   publish-to-pypi:
     name: Publish Python wheels to PyPI
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built Python wheels are now automatically attached to GitHub Releases after CI builds.

* **Chores**
  * CI permissions updated to allow write access during workflow runs.
  * macOS runners for macOS build jobs upgraded to newer versions to use more recent macOS environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->