### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4836,7 +4836,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-common"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ahash",
  "arrow",
@@ -4860,7 +4860,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-core"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "ahash",
  "async-trait",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-runtime"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "async-lock",
  "async-mutex",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-server"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-wasm"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/vegafusion-common/Cargo.toml
+++ b/vegafusion-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vegafusion-common"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Common components required by multiple VegaFusion crates"
 license = "BSD-3-Clause"

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vegafusion-core"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "2.1.0"
+version = "2.1.1"
 description = "Core components required by multiple VegaFusion crates, with WASM compatibility"
 
 [features]
@@ -45,7 +45,7 @@ features = ["preserve_order"]
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.datafusion-common]
 workspace = true

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vegafusion"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "2.1.0"
+version = "2.1.1"
 description = "VegaFusion Python interface"
 
 [lib]
@@ -52,16 +52,16 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["pyo3", "base64"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["py", "tonic_support"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.datafusion]
 workspace = true

--- a/vegafusion-python/pyproject.toml
+++ b/vegafusion-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepnote_vegafusion"
-version = "2.1.0"
+version = "2.1.1"
 description = "Core tools for using VegaFusion from Python"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -6,7 +6,7 @@ harness = false
 name = "vegafusion-runtime"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "2.1.0"
+version = "2.1.1"
 description = "VegaFusion Runtime"
 
 [features]
@@ -115,12 +115,12 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser", "prettyprint", "object_store", "url"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["sqlparser"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.serde]
 workspace = true

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 name = "vegafusion-server"
 license = "BSD-3-Clause"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "VegaFusion Server"
 repository = "https://github.com/vega/vegafusion"
@@ -35,16 +35,16 @@ workspace = true
 
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["tonic_support"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.tokio]
 workspace = true

--- a/vegafusion-wasm/Cargo.toml
+++ b/vegafusion-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vegafusion-wasm"
 license = "BSD-3-Clause"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "VegaFusion WASM package for embedding Vega charts in the browser with a connection to a VegaFusion Runtime"
 
@@ -41,15 +41,15 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json"]
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
-version = "2.1.0"
+version = "2.1.1"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "2.1.0"
+version = "2.1.1"
 default-features = false
 features = ["http-wasm"]
 

--- a/vegafusion-wasm/package-lock.json
+++ b/vegafusion-wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vegafusion-wasm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/vegafusion-wasm/package.json
+++ b/vegafusion-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vegafusion-wasm",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "author": "Jon Mease <jon@vegafusion.io> (https://jonmmease.dev)",
   "license": "BSD-3-Clause",
   "description": "Wasm library for interfacing with VegaFusion",


### PR DESCRIPTION
Version bump to `2.1.1` in preparation for the next release, generated with `automation/bump_version.py` (`pixi run bump-version 2.1.1`) plus `cargo update --workspace` to refresh `Cargo.lock`.

Only version strings change — the diff is line-for-line the same shape as the previous bump (4c526a4a).

Changes since [v2.1.0](https://github.com/deepnote/vegafusion/releases/tag/v2.1.0):
* fix: Accept any fractional-second precision when parsing timestamp strings (#25)

After merge, publish a GitHub Release tagged `v2.1.1` on the merge commit — that triggers `.github/workflows/release.yml`, which builds all-platform wheels, attaches them to the release, and publishes `deepnote-vegafusion` 2.1.1 to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSBPh6sGS1DeMA7GEabXAz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the VegaFusion packages and components to version **2.1.1**.
  * Synchronized package metadata and internal version references across supported distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->